### PR TITLE
Add student score system and teacher_assistant role

### DIFF
--- a/app/components/AddScorePopup.tsx
+++ b/app/components/AddScorePopup.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { fieldValidators } from "@/lib/validations";
+import { insertScore } from "@/services/scoresService";
+import { getFriendlyErrorMessage } from "@/lib/utils";
+import { ScoreData } from "@/types";
+
+const AddScorePopup = ({
+  groupName,
+  setShowAddPopup,
+  onAdded,
+}: {
+  groupName: string;
+  setShowAddPopup: (value: boolean) => void;
+  onAdded: (student: ScoreData) => void;
+}) => {
+  const [name, setName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleAddStudent = useCallback(async () => {
+    setIsSubmitting(true);
+    const error = await fieldValidators.scoreName(name);
+    if (error) {
+      toast.error(error, { duration: 5000 });
+      setIsSubmitting(false);
+      return;
+    }
+    try {
+      const { error } = await insertScore(name.trim(), groupName);
+
+      if (error) {
+        toast.error(getFriendlyErrorMessage(error), { duration: 5000 });
+      } else {
+        toast.success("Student added successfully!", { duration: 5000 });
+        onAdded({ name: name.trim().toLowerCase(), score: 0, group: groupName });
+        setShowAddPopup(false);
+      }
+    } catch {
+      toast.error("Unexpected error. Please try again.", { duration: 5000 });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [name, groupName, setShowAddPopup, onAdded]);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      handleAddStudent();
+    },
+    [handleAddStudent]
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        if (isSubmitting) return;
+        event.preventDefault();
+        setShowAddPopup(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [setShowAddPopup, isSubmitting]);
+
+  return (
+    <div className="fixed inset-0 bg-white/50 backdrop-blur-sm flex items-center justify-center z-50">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-lg p-6 w-full max-w-md mx-4 shadow-xl"
+      >
+        <h2 className="text-xl font-bold mb-4">Add Student</h2>
+        <div className="space-y-4">
+          <input
+            type="text"
+            placeholder="Full Name"
+            className="input w-full"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+            required
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="flex justify-end gap-3 mt-6">
+          <button
+            type="button"
+            className="btn"
+            onClick={() => setShowAddPopup(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+          <button type="submit" className="btn dark-btn" disabled={isSubmitting}>
+            Add
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default AddScorePopup;

--- a/app/components/DesktopNavbar.tsx
+++ b/app/components/DesktopNavbar.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { CircleChevronDown, CircleUser } from "lucide-react";
 import { useState } from "react";
 import Loading from "./Loading";
+import { getProfileRole } from "@/lib/utils";
 
 const DesktopNavbar = () => {
   const { user, loading } = useAuth();
@@ -29,22 +30,36 @@ const DesktopNavbar = () => {
           <li>
             <Link href="/contact">Contact</Link>
           </li>
+          <li>
+            <Link href="/scores">Scores</Link>
+          </li>
           {user && (
             <li>
               <Link
                 href={
-                  user.user_metadata.role === "admin"
+                  user.user_metadata.role === "admin" ||
+                  user.user_metadata.role === "teacher_assistant"
                     ? `/groups`
                     : `/group/${user.user_metadata.group}`
                 }
               >
-                {user.user_metadata.role === "admin" ? "Groups" : "Group"}
+                {user.user_metadata.role === "admin" ||
+                user.user_metadata.role === "teacher_assistant"
+                  ? "Groups"
+                  : "Group"}
               </Link>
             </li>
           )}
           {user && user.user_metadata.role === "admin" && (
             <li>
               <Link href={`/students`}>Students</Link>
+            </li>
+          )}
+          {user && user.user_metadata.role === "teacher" && (
+            <li>
+              <Link href={`/scores/manage/${user.user_metadata.group}`}>
+                Edit Scores
+              </Link>
             </li>
           )}
           {user && user.user_metadata.role === "admin" && (
@@ -88,9 +103,9 @@ const DesktopNavbar = () => {
         </ul>
         {user ? (
           <Link
-            href={`/u/${
-              user.user_metadata.role ? user.user_metadata.role : "student"
-            }/${user.user_metadata.username}`}
+            href={`/u/${getProfileRole(user.user_metadata.role)}/${
+              user.user_metadata.username
+            }`}
             className=""
           >
             {user.user_metadata.profileImageUrl ? (

--- a/app/components/GroupScores.tsx
+++ b/app/components/GroupScores.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { notFound, redirect } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import { capitalize, getFriendlyErrorMessage } from "@/lib/utils";
+import { ScoreData } from "@/types";
+import {
+  fetchGroupScores,
+  updateScore,
+  deleteScore,
+} from "@/services/scoresService";
+import toast from "react-hot-toast";
+import Loading from "./Loading";
+import AddScorePopup from "./AddScorePopup";
+import { Minus, Plus, Trash2 } from "lucide-react";
+
+const GroupScores = ({ groupName }: { groupName: string }) => {
+  const { user, loading: authLoading } = useAuth();
+  const [students, setStudents] = useState<ScoreData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAddPopup, setShowAddPopup] = useState(false);
+  const [editingName, setEditingName] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState("");
+
+  const isAdmin = user?.user_metadata.role === "admin";
+  const isOwningTeacher =
+    user?.user_metadata.role === "teacher" &&
+    user?.user_metadata.group === groupName;
+  const isTeacherAssistant = user?.user_metadata.role === "teacher_assistant";
+  const canView = isAdmin || isOwningTeacher || isTeacherAssistant;
+  const canManageStudents = isAdmin || isOwningTeacher;
+
+  useEffect(() => {
+    if (!canView) return;
+
+    const loadStudents = async () => {
+      try {
+        const data = await fetchGroupScores(groupName);
+        setStudents(data.filter((student) => !student.error));
+      } catch {
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadStudents();
+  }, [groupName, canView]);
+
+  if (authLoading) {
+    return <Loading />;
+  }
+
+  if (!user) redirect("/signin?m=sr");
+  if (!canView) notFound();
+
+  const handleScoreChange = async (name: string, newScore: number) => {
+    const safeScore = Math.max(0, newScore);
+    const { error } = await updateScore(name, safeScore);
+
+    if (error) {
+      toast.error(getFriendlyErrorMessage(error), { duration: 5000 });
+      return;
+    }
+
+    setStudents((prev) =>
+      prev.map((student) =>
+        student.name === name ? { ...student, score: safeScore } : student
+      )
+    );
+  };
+
+  const handleDelete = async (name: string) => {
+    if (!window.confirm(`Remove ${capitalize(name)} from the score list?`)) {
+      return;
+    }
+
+    const { error } = await deleteScore(name);
+
+    if (error) {
+      toast.error(getFriendlyErrorMessage(error), { duration: 5000 });
+      return;
+    }
+
+    toast.success("Student removed", { duration: 5000 });
+    setStudents((prev) => prev.filter((student) => student.name !== name));
+  };
+
+  const startEditing = (student: ScoreData) => {
+    setEditingName(student.name);
+    setEditingValue(String(student.score));
+  };
+
+  const commitEditing = async () => {
+    if (editingName === null) return;
+    const parsed = parseInt(editingValue, 10);
+    if (!isNaN(parsed)) {
+      await handleScoreChange(editingName, parsed);
+    }
+    setEditingName(null);
+  };
+
+  if (loading) {
+    return (
+      <main className="main-container flex-grow-1 py-8">
+        <p className="text-center text-gray-500">Loading students...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="main-container flex-grow-1 py-8">
+      <h1 className="text-3xl font-bold mb-6 text-center">
+        {capitalize(groupName)} Scores
+      </h1>
+      {students.length === 0 ? (
+        <p className="text-center text-gray-500 mb-8">No students yet</p>
+      ) : (
+        <div className="flex flex-col gap-3 max-w-2xl mx-auto mb-8">
+          {students.map((student) => (
+            <div
+              key={student.name}
+              className="flex items-center justify-between gap-4 rounded-xl border border-gray-200 bg-white p-4"
+            >
+              <span className="font-semibold truncate">
+                {capitalize(student.name)}
+              </span>
+              <div className="flex items-center gap-3 shrink-0">
+                <button
+                  type="button"
+                  className="btn light-btn border border-gray-200 p-2"
+                  onClick={() => handleScoreChange(student.name, student.score - 1)}
+                  aria-label={`Decrease score for ${student.name}`}
+                >
+                  <Minus className="size-4" />
+                </button>
+                {editingName === student.name ? (
+                  <input
+                    type="number"
+                    className="input w-20 text-center"
+                    value={editingValue}
+                    autoFocus
+                    onChange={(e) => setEditingValue(e.target.value)}
+                    onBlur={commitEditing}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") commitEditing();
+                      if (e.key === "Escape") setEditingName(null);
+                    }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    className="font-bold text-primary text-lg w-12 text-center cursor-pointer"
+                    onClick={() => startEditing(student)}
+                  >
+                    {student.score}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="btn light-btn border border-gray-200 p-2"
+                  onClick={() => handleScoreChange(student.name, student.score + 1)}
+                  aria-label={`Increase score for ${student.name}`}
+                >
+                  <Plus className="size-4" />
+                </button>
+                {canManageStudents && (
+                  <button
+                    type="button"
+                    className="text-red-500 p-2 cursor-pointer"
+                    onClick={() => handleDelete(student.name)}
+                    aria-label={`Remove ${student.name}`}
+                  >
+                    <Trash2 className="size-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {canManageStudents && (
+        <button
+          type="button"
+          className="btn dark-btn block mx-auto"
+          onClick={() => setShowAddPopup(true)}
+        >
+          Add Student
+        </button>
+      )}
+      {canManageStudents && showAddPopup && (
+        <AddScorePopup
+          groupName={groupName}
+          setShowAddPopup={setShowAddPopup}
+          onAdded={(student) => setStudents((prev) => [...prev, student])}
+        />
+      )}
+    </main>
+  );
+};
+
+export default GroupScores;

--- a/app/components/Groups.tsx
+++ b/app/components/Groups.tsx
@@ -9,6 +9,7 @@ import Loading from "./Loading";
 import { notFound, redirect } from "next/navigation";
 import { fetchGroups } from "@/services/groupService";
 import Image from "next/image";
+import Link from "next/link";
 import CreatePopup from "./CreatePopup";
 import supabase from "@/lib/supabaseClient";
 
@@ -23,9 +24,7 @@ const Groups = () => {
     const loadGroups = async () => {
       try {
         const data = await fetchGroups();
-        setGroups(
-          data.filter((group) => group.group_name?.toLowerCase() !== "admin")
-        );
+        setGroups(data);
       } catch {
       } finally {
         setLoading(false);
@@ -86,8 +85,11 @@ const Groups = () => {
     return <Loading />;
   }
 
+  const isAdmin = user?.user_metadata.role === "admin";
+  const isTeacherAssistant = user?.user_metadata.role === "teacher_assistant";
+
   if (!user) redirect("/signin?m=sr");
-  if (user.user_metadata.role !== "admin") notFound();
+  if (!isAdmin && !isTeacherAssistant) notFound();
 
   if (loading) {
     return (
@@ -130,9 +132,10 @@ const Groups = () => {
       {filteredGroups.length > 0 && (
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredGroups.map((group) => (
-            <div
+            <Link
               key={group.id}
-              className="border border-gray-200 rounded-lg p-4 bg-white shadow-2xl hover:scale-105 transition-transform duration-200"
+              href={`/scores/manage/${group.group_name}`}
+              className="border border-gray-200 rounded-lg p-4 bg-white shadow-2xl hover:scale-105 transition-transform duration-200 cursor-pointer"
             >
               <Image
                 src="/group.png"
@@ -147,17 +150,19 @@ const Groups = () => {
                 </h2>
                 <span>{group.closed ? "Closed" : "Open"}</span>
               </div>
-            </div>
+            </Link>
           ))}
         </section>
       )}
-      <button
-        className="btn dark-btn mt-8 block mx-auto lg:ml-auto lg:mx-0"
-        onClick={() => setShowCreatePopup(true)}
-      >
-        Create New Group
-      </button>
-      {showCreatePopup && (
+      {isAdmin && (
+        <button
+          className="btn dark-btn mt-8 block mx-auto lg:ml-auto lg:mx-0"
+          onClick={() => setShowCreatePopup(true)}
+        >
+          Create New Group
+        </button>
+      )}
+      {isAdmin && showCreatePopup && (
         <CreatePopup setShowCreatePopup={setShowCreatePopup} />
       )}
     </main>

--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -7,6 +7,7 @@ import Loading from "./Loading";
 import { useEffect } from "react";
 import supabase from "@/lib/supabaseClient";
 import toast from "react-hot-toast";
+import { getProfileRole } from "@/lib/utils";
 
 const HomePage = () => {
   const { user, loading } = useAuth();
@@ -53,9 +54,9 @@ const HomePage = () => {
             </p>
             {user ? (
               <Link
-                href={`/u/${
-                  user.user_metadata.role ? user.user_metadata.role : "student"
-                }/${user.user_metadata.username}`}
+                href={`/u/${getProfileRole(user.user_metadata.role)}/${
+                  user.user_metadata.username
+                }`}
                 className="btn light-btn inline-block mx-auto lg:mx-0"
               >
                 Dashboard

--- a/app/components/MobileNavbar.tsx
+++ b/app/components/MobileNavbar.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import Loading from "./Loading";
 import { Bars3BottomLeftIcon, XMarkIcon } from "@heroicons/react/24/solid";
-import { capitalize } from "@/lib/utils";
+import { capitalize, getProfileRole } from "@/lib/utils";
 
 const MobileNavbar = () => {
   const { user, loading } = useAuth();
@@ -50,22 +50,36 @@ const MobileNavbar = () => {
               <li>
                 <Link href="/contact">Contact</Link>
               </li>
+              <li>
+                <Link href="/scores">Scores</Link>
+              </li>
               {user && (
                 <li>
                   <Link
                     href={
-                      user.user_metadata.role === "admin"
+                      user.user_metadata.role === "admin" ||
+                      user.user_metadata.role === "teacher_assistant"
                         ? `/groups`
                         : `/group/${user.user_metadata.group}`
                     }
                   >
-                    {user.user_metadata.role === "admin" ? "Groups" : "Group"}
+                    {user.user_metadata.role === "admin" ||
+                    user.user_metadata.role === "teacher_assistant"
+                      ? "Groups"
+                      : "Group"}
                   </Link>
                 </li>
               )}
               {user && user.user_metadata.role === "admin" && (
                 <li>
                   <Link href={`/students`}>Students</Link>
+                </li>
+              )}
+              {user && user.user_metadata.role === "teacher" && (
+                <li>
+                  <Link href={`/scores/manage/${user.user_metadata.group}`}>
+                    Edit Scores
+                  </Link>
                 </li>
               )}
               {user && user.user_metadata.role === "admin" && (
@@ -92,9 +106,9 @@ const MobileNavbar = () => {
       </Link>
       {user ? (
         <Link
-          href={`/u/${
-            user.user_metadata.role ? user.user_metadata.role : "student"
-          }/${user.user_metadata.username}`}
+          href={`/u/${getProfileRole(user.user_metadata.role)}/${
+            user.user_metadata.username
+          }`}
           className="ml-auto"
         >
           {user.user_metadata.profileImageUrl ? (

--- a/app/components/Scores.tsx
+++ b/app/components/Scores.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { capitalize } from "@/lib/utils";
+import { ScoreData } from "@/types";
+import { fetchAllScores } from "@/services/scoresService";
+import supabase from "@/lib/supabaseClient";
+
+const rankStyles: Record<number, string> = {
+  0: "bg-yellow-100 border-yellow-400",
+  1: "bg-gray-100 border-gray-400",
+  2: "bg-orange-100 border-orange-400",
+};
+
+const rankMedals: Record<number, string> = {
+  0: "🥇",
+  1: "🥈",
+  2: "🥉",
+};
+
+const Scores = () => {
+  const [scores, setScores] = useState<ScoreData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadScores = async () => {
+      try {
+        const data = await fetchAllScores();
+        setScores(data.filter((score) => !score.error));
+      } catch {
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadScores();
+  }, []);
+
+  useEffect(() => {
+    const channel = supabase
+      .channel("student-scores-changes")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "student_scores" },
+        () => {
+          fetchAllScores().then((data) =>
+            setScores(data.filter((score) => !score.error))
+          );
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <main className="main-container flex-grow-1 py-8">
+        <h1 className="text-3xl font-bold mb-6 text-center">Leaderboard</h1>
+        <p className="text-center text-gray-500">Loading scores...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="main-container flex-grow-1 py-8">
+      <h1 className="text-3xl font-bold mb-6 text-center">Leaderboard</h1>
+      {scores.length === 0 ? (
+        <p className="text-center text-gray-500">No scores yet</p>
+      ) : (
+        <div className="flex flex-col gap-3 max-w-2xl mx-auto">
+          {scores.map((student, index) => (
+            <div
+              key={student.name}
+              className={`flex items-center justify-between gap-4 rounded-xl border p-4 ${
+                rankStyles[index] || "bg-white border-gray-200"
+              }`}
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <span className="font-bold text-secondary w-8 shrink-0">
+                  {rankMedals[index] || `#${index + 1}`}
+                </span>
+                <span className="font-semibold truncate">
+                  {capitalize(student.name)}
+                </span>
+              </div>
+              <div className="flex items-center gap-6 shrink-0">
+                <span className="text-sm text-secondary">
+                  {capitalize(student.group)}
+                </span>
+                <span className="font-bold text-primary text-lg">
+                  {student.score}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+};
+
+export default Scores;

--- a/app/components/SignUpForm.tsx
+++ b/app/components/SignUpForm.tsx
@@ -22,22 +22,6 @@ const SignUpForm = () => {
   const pathname = usePathname();
   const { user, loading: authLoading } = useAuth();
 
-  useEffect(() => {
-    const loadFormConfig = async () => {
-      try {
-        const signUpFormConfig = pathname.includes("admin")
-          ? await getAdminSignUpFormConfig()
-          : await getStudentSignUpFormConfig();
-        setSignUpFormConfig(signUpFormConfig);
-      } catch {
-        setSignUpFormConfig([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadFormConfig();
-  }, [pathname]);
   const {
     values,
     errors,
@@ -48,6 +32,23 @@ const SignUpForm = () => {
     clearErrors,
     resetForm,
   } = useFormFields(signUpFormConfig, setServerError);
+
+  useEffect(() => {
+    const loadFormConfig = async () => {
+      try {
+        const signUpFormConfig = pathname.includes("admin")
+          ? await getAdminSignUpFormConfig(values.role as string | undefined)
+          : await getStudentSignUpFormConfig();
+        setSignUpFormConfig(signUpFormConfig);
+      } catch {
+        setSignUpFormConfig([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadFormConfig();
+  }, [pathname, values.role]);
   const { error, submitAction, isPending } = useSignUpMagicLink(resetForm);
   useEffect(() => {
     if (error) {

--- a/app/new-user/signUpFormConfig.ts
+++ b/app/new-user/signUpFormConfig.ts
@@ -68,13 +68,15 @@ export const getStudentSignUpFormConfig = async (): Promise<FormField[]> => {
   ];
 };
 
-export const getAdminSignUpFormConfig = async (): Promise<FormField[]> => {
+export const getAdminSignUpFormConfig = async (
+  role?: string
+): Promise<FormField[]> => {
   const groups = await fetchGroups();
   const groupOptions = groups
     .map((group) => group.group_name)
     .filter((name): name is string => name !== undefined);
 
-  return [
+  const fields: FormField[] = [
     {
       name: "fullname",
       label: "Full Name",
@@ -105,7 +107,7 @@ export const getAdminSignUpFormConfig = async (): Promise<FormField[]> => {
       label: "Role",
       type: "datalist",
       id: "role",
-      options: ["admin", "teacher"],
+      options: ["admin", "teacher", "teacher_assistant"],
       validation: fieldValidators.role,
     },
     {
@@ -116,7 +118,10 @@ export const getAdminSignUpFormConfig = async (): Promise<FormField[]> => {
       defaultValue: new Date().toISOString().split("T")[0],
       validation: fieldValidators.joinedOn,
     },
-    {
+  ];
+
+  if (role === "teacher") {
+    fields.push({
       name: "group",
       label: "Group",
       type: "datalist",
@@ -124,13 +129,16 @@ export const getAdminSignUpFormConfig = async (): Promise<FormField[]> => {
       options: groupOptions,
       placeholder: "Select Group",
       validation: fieldValidators.group,
-    },
-    {
-      name: "profileImage",
-      label: "Profile Image",
-      type: "file",
-      id: "profile-image",
-      validation: fieldValidators.profileImage,
-    },
-  ];
+    });
+  }
+
+  fields.push({
+    name: "profileImage",
+    label: "Profile Image",
+    type: "file",
+    id: "profile-image",
+    validation: fieldValidators.profileImage,
+  });
+
+  return fields;
 };

--- a/app/scores/manage/[groupName]/page.tsx
+++ b/app/scores/manage/[groupName]/page.tsx
@@ -1,0 +1,22 @@
+import Footer from "@/app/components/Footer";
+import GroupScores from "@/app/components/GroupScores";
+import Navbar from "@/app/components/Navbar";
+
+const ManageGroupScoresPage = async ({
+  params,
+}: {
+  params: Promise<{ groupName: string }>;
+}) => {
+  const { groupName } = await params;
+  const groupNameFromURL = decodeURIComponent(groupName);
+
+  return (
+    <>
+      <Navbar />
+      <GroupScores groupName={groupNameFromURL} />
+      <Footer />
+    </>
+  );
+};
+
+export default ManageGroupScoresPage;

--- a/app/scores/page.tsx
+++ b/app/scores/page.tsx
@@ -1,0 +1,15 @@
+import Footer from "@/app/components/Footer";
+import Navbar from "@/app/components/Navbar";
+import Scores from "@/app/components/Scores";
+
+const ScoresPage = () => {
+  return (
+    <>
+      <Navbar />
+      <Scores />
+      <Footer />
+    </>
+  );
+};
+
+export default ScoresPage;

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -102,7 +102,7 @@ export const AuthProvider = ({
             username: userData.username.toLowerCase(),
             dateOfBirth: userData.dateOfBirth,
             joinedOn: userData.joinedOn,
-            group: userData.group.toLowerCase(),
+            group: userData.group ? userData.group.toLowerCase() : null,
             profileImageUrl: profileImageUrl,
             role: userData.role?.toLowerCase(),
           },

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -21,6 +21,11 @@ export const capitalize = (str: string) => {
   return result;
 };
 
+export const getProfileRole = (role?: string) => {
+  if (role === "teacher_assistant") return "teacher";
+  return role || "student";
+};
+
 export const getAge = (dateOfBirth: string) => {
   const today = new Date();
   const birthDate = new Date(dateOfBirth);

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -3,13 +3,17 @@ import {
   fetchStudentUsernames,
   fetchAdminUsernames,
   fetchTeacherUsernames,
+  fetchTeacherAssistantUsernames,
 } from "@/services/usernameService";
+import { fetchScoreNames } from "@/services/scoresService";
 import type { ValidationResult, ValidationFunction, FormValue } from "@/types";
 
 let groupOptionsCache: string[] | null = null;
 let studentUsernamesCache: string[] | null = null;
 let adminUsernamesCache: string[] | null = null;
 let teacherUsernamesCache: string[] | null = null;
+let teacherAssistantUsernamesCache: string[] | null = null;
+let scoreNamesCache: string[] | null = null;
 
 const getGroupOptions = async (): Promise<string[]> => {
   if (!groupOptionsCache) {
@@ -40,6 +44,20 @@ const getTeacherUsernames = async (): Promise<string[]> => {
     teacherUsernamesCache = await fetchTeacherUsernames();
   }
   return teacherUsernamesCache;
+};
+
+const getTeacherAssistantUsernames = async (): Promise<string[]> => {
+  if (!teacherAssistantUsernamesCache) {
+    teacherAssistantUsernamesCache = await fetchTeacherAssistantUsernames();
+  }
+  return teacherAssistantUsernamesCache;
+};
+
+const getScoreNames = async (): Promise<string[]> => {
+  if (!scoreNamesCache) {
+    scoreNamesCache = await fetchScoreNames();
+  }
+  return scoreNamesCache;
 };
 
 export const validations = {
@@ -91,6 +109,7 @@ export const validations = {
     const studentUsernames = await getStudentUsernames();
     const adminUsernames = await getAdminUsernames();
     const teacherUsernames = await getTeacherUsernames();
+    const teacherAssistantUsernames = await getTeacherAssistantUsernames();
 
     const studentUsername = studentUsernames.find(
       (username) => username.toLowerCase() === value.toLowerCase()
@@ -101,10 +120,18 @@ export const validations = {
     const teacherUsername = teacherUsernames.find(
       (username) => username.toLowerCase() === value.toLowerCase()
     );
+    const teacherAssistantUsername = teacherAssistantUsernames.find(
+      (username) => username.toLowerCase() === value.toLowerCase()
+    );
     if (!/^[a-zA-Z0-9_]+$/.test(value)) {
       return "Username can only contain letters, numbers, and underscores";
     }
-    if (studentUsername || adminUsername || teacherUsername) {
+    if (
+      studentUsername ||
+      adminUsername ||
+      teacherUsername ||
+      teacherAssistantUsername
+    ) {
       return "Username is already taken";
     }
     return null;
@@ -185,10 +212,27 @@ export const validations = {
   role: (value: FormValue): ValidationResult => {
     if (typeof value !== "string") return null;
 
-    const selectedOption = ["admin", "teacher"].find(
+    const selectedOption = ["admin", "teacher", "teacher_assistant"].find(
       (option) => option.toLowerCase() === value.toLowerCase()
     );
     return !selectedOption ? `${value} is not an option` : null;
+  },
+
+  scoreName: async (value: FormValue): Promise<ValidationResult> => {
+    if (typeof value !== "string") return null;
+
+    if (!/^[a-zA-Z ]+$/.test(value)) {
+      return "Name can only contain letters and spaces";
+    }
+
+    const scoreNames = await getScoreNames();
+    const existingName = scoreNames.find(
+      (name) => name.toLowerCase() === value.trim().toLowerCase()
+    );
+    if (existingName) {
+      return "This student is already in the score list";
+    }
+    return null;
   },
 };
 
@@ -240,6 +284,12 @@ export const fieldValidators = {
   profileImage: createValidator(
     validations.fileSize(5),
     validations.fileType(["image/png", "image/jpeg", "image/webp"])
+  ),
+
+  scoreName: createValidator(
+    validations.required("Name"),
+    validations.minLength(2, "Name"),
+    validations.scoreName
   ),
 };
 

--- a/services/scoresService.ts
+++ b/services/scoresService.ts
@@ -1,0 +1,58 @@
+import supabase from "@/lib/supabaseClient";
+import { ScoreData } from "@/types";
+
+export const fetchAllScores = async (): Promise<ScoreData[]> => {
+  const { data, error } = await supabase
+    .from("student_scores")
+    .select("name, score, group")
+    .order("score", { ascending: false });
+
+  if (error) {
+    return [{ name: "", score: 0, group: "", error: error.message }];
+  }
+
+  return data;
+};
+
+export const fetchGroupScores = async (
+  groupName: string
+): Promise<ScoreData[]> => {
+  const { data, error } = await supabase
+    .from("student_scores")
+    .select("name, score, group")
+    .eq("group", groupName)
+    .order("score", { ascending: false });
+
+  if (error) {
+    return [{ name: "", score: 0, group: "", error: error.message }];
+  }
+
+  return data;
+};
+
+export const fetchScoreNames = async (): Promise<string[]> => {
+  const { data, error } = await supabase.from("student_scores").select("name");
+
+  if (error) {
+    return [error.message];
+  }
+
+  return data.map((record) => record.name);
+};
+
+export const insertScore = async (name: string, group: string) => {
+  return await supabase
+    .from("student_scores")
+    .insert({ name: name.toLowerCase(), score: 0, group });
+};
+
+export const updateScore = async (name: string, score: number) => {
+  return await supabase
+    .from("student_scores")
+    .update({ score })
+    .eq("name", name);
+};
+
+export const deleteScore = async (name: string) => {
+  return await supabase.from("student_scores").delete().eq("name", name);
+};

--- a/services/usernameService.ts
+++ b/services/usernameService.ts
@@ -37,3 +37,16 @@ export const fetchTeacherUsernames = async () => {
 
   return data.map((teacher) => teacher.username);
 };
+
+export const fetchTeacherAssistantUsernames = async () => {
+  const { data, error } = await supabase
+    .from("teacher_profiles")
+    .select("username")
+    .eq("role", "teacher_assistant");
+
+  if (error) {
+    return [error.message];
+  }
+
+  return data.map((teacherAssistant) => teacherAssistant.username);
+};

--- a/types.ts
+++ b/types.ts
@@ -62,7 +62,7 @@ export interface SignUpUserData {
   fullname: string;
   username: string;
   joinedOn: string;
-  group: string;
+  group?: string;
   dateOfBirth?: string;
   role?: string;
   profileImage?: File;
@@ -86,6 +86,13 @@ export interface GroupData {
 export interface LessonContentsData {
   lesson_name?: string;
   lesson_book?: string;
+  error?: string;
+}
+
+export interface ScoreData {
+  name: string;
+  score: number;
+  group: string;
   error?: string;
 }
 


### PR DESCRIPTION
- New public leaderboard (/scores) and teacher/admin score editor (/scores/manage/[groupName]) backed by a new student_scores table
- New teacher_assistant role: can edit scores for any group but not add/delete students, reuses the existing teacher profile route
- Admin signup form now only shows the Group field for the teacher role, since admins/TAs aren't scoped to a single group