### PR TITLE
Split fullname into first/last name fields with Arabic support

### DIFF
--- a/app/components/AddScorePopup.tsx
+++ b/app/components/AddScorePopup.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import toast from "react-hot-toast";
-import { getFieldValidators } from "@/lib/validations";
+import { getFieldValidators, getValidations } from "@/lib/validations";
 import { insertScore } from "@/services/scoresService";
 import { getFriendlyErrorMessage } from "@/lib/utils";
 import { ScoreData } from "@/types";
@@ -16,25 +16,49 @@ const AddScorePopup = ({
   onAdded: (student: ScoreData) => void;
 }) => {
   const { t } = useLanguage();
-  const [name, setName] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleAddStudent = useCallback(async () => {
     setIsSubmitting(true);
-    const error = await getFieldValidators(t).scoreName(name);
+    const validations = getValidations(t);
+
+    const firstNameError =
+      (await validations.required(t("formFields.firstName"))(firstName)) ||
+      (await validations.fullname(firstName));
+    const lastNameError =
+      (await validations.required(t("formFields.lastName"))(lastName)) ||
+      (await validations.fullname(lastName));
+    if (firstNameError || lastNameError) {
+      toast.error(firstNameError || lastNameError, { duration: 5000 });
+      setIsSubmitting(false);
+      return;
+    }
+
+    const combinedName = `${firstName.replace(/\s+/g, "")} ${lastName.replace(
+      /\s+/g,
+      ""
+    )}`;
+
+    const error = await getFieldValidators(t).scoreName(combinedName);
     if (error) {
       toast.error(error, { duration: 5000 });
       setIsSubmitting(false);
       return;
     }
     try {
-      const { error } = await insertScore(name.trim(), groupName);
+      const { error } = await insertScore(combinedName, groupName);
 
       if (error) {
         toast.error(getFriendlyErrorMessage(error, t), { duration: 5000 });
       } else {
         toast.success(t("addScorePopup.successToast"), { duration: 5000 });
-        onAdded({ name: name.trim().toLowerCase(), score: 0, group: groupName });
+        onAdded({
+          name: combinedName.toLowerCase(),
+          score: 0,
+          group: groupName,
+        });
         setShowAddPopup(false);
       }
     } catch {
@@ -42,7 +66,7 @@ const AddScorePopup = ({
     } finally {
       setIsSubmitting(false);
     }
-  }, [name, groupName, setShowAddPopup, onAdded, t]);
+  }, [firstName, lastName, groupName, setShowAddPopup, onAdded, t]);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -78,11 +102,20 @@ const AddScorePopup = ({
         <div className="space-y-4">
           <input
             type="text"
-            placeholder={t("addScorePopup.fullNamePlaceholder")}
+            placeholder={t("formFields.firstName")}
             className="input w-full"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
             autoFocus
+            required
+            disabled={isSubmitting}
+          />
+          <input
+            type="text"
+            placeholder={t("formFields.lastName")}
+            className="input w-full"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
             required
             disabled={isSubmitting}
           />

--- a/app/hooks/useSignUpMagicLink.ts
+++ b/app/hooks/useSignUpMagicLink.ts
@@ -23,7 +23,8 @@ export const useSignUpMagicLink = (resetForm: () => void) => {
 
         if (!result?.success) {
           return new Error(
-            result?.errors?.fullname ||
+            result?.errors?.firstName ||
+              result?.errors?.lastName ||
               result?.errors?.username ||
               result?.errors?.dateOfBirth ||
               result?.errors?.email ||

--- a/app/new-user/admin/action.ts
+++ b/app/new-user/admin/action.ts
@@ -11,8 +11,19 @@ export const signUpNewAdminAction = async (
   const locale = ((await cookies()).get("locale")?.value as Locale) || "en";
   const fieldValidators = getFieldValidators(getTranslator(locale));
 
+  const firstName = formData.get("firstName")?.toString() || "";
+  const lastName = formData.get("lastName")?.toString() || "";
+
+  const { isValid: isNameValid, errors: nameErrors } = await validateFormData(
+    { firstName, lastName },
+    { firstName: fieldValidators.firstName, lastName: fieldValidators.lastName }
+  );
+
   const data: SignUpUserData = {
-    fullname: formData.get("fullname")?.toString() || "",
+    fullname: `${firstName.replace(/\s+/g, "")} ${lastName.replace(
+      /\s+/g,
+      ""
+    )}`,
     username: formData.get("username")?.toString() || "",
     email: formData.get("email")?.toString() || "",
     joinedOn: formData.get("joinedOn")?.toString() || "",
@@ -22,7 +33,6 @@ export const signUpNewAdminAction = async (
   };
 
   const { isValid, errors } = await validateFormData(data, {
-    fullname: fieldValidators.fullname,
     username: fieldValidators.username,
     email: fieldValidators.email,
     joinedOn: fieldValidators.joinedOn,
@@ -30,10 +40,10 @@ export const signUpNewAdminAction = async (
     role: fieldValidators.role,
   });
 
-  if (!isValid) {
+  if (!isNameValid || !isValid) {
     return {
       success: false,
-      errors,
+      errors: { ...nameErrors, ...errors },
     };
   }
 

--- a/app/new-user/signUpFormConfig.ts
+++ b/app/new-user/signUpFormConfig.ts
@@ -13,13 +13,21 @@ export const getStudentSignUpFormConfig = async (
 
   return [
     {
-      name: "fullname",
-      label: t("formFields.fullname"),
+      name: "firstName",
+      label: t("formFields.firstName"),
       type: "text",
-      placeholder: t("formFields.fullnamePlaceholder"),
-      id: "fullname",
+      placeholder: t("formFields.firstNamePlaceholder"),
+      id: "first-name",
       autoFocus: true,
-      validation: fieldValidators.fullname,
+      validation: fieldValidators.firstName,
+    },
+    {
+      name: "lastName",
+      label: t("formFields.lastName"),
+      type: "text",
+      placeholder: t("formFields.lastNamePlaceholder"),
+      id: "last-name",
+      validation: fieldValidators.lastName,
     },
     {
       name: "username",
@@ -83,13 +91,21 @@ export const getAdminSignUpFormConfig = async (
 
   const fields: FormField[] = [
     {
-      name: "fullname",
-      label: t("formFields.fullname"),
+      name: "firstName",
+      label: t("formFields.firstName"),
       type: "text",
-      placeholder: t("formFields.fullnamePlaceholder"),
-      id: "fullname",
+      placeholder: t("formFields.firstNamePlaceholder"),
+      id: "first-name",
       autoFocus: true,
-      validation: fieldValidators.fullname,
+      validation: fieldValidators.firstName,
+    },
+    {
+      name: "lastName",
+      label: t("formFields.lastName"),
+      type: "text",
+      placeholder: t("formFields.lastNamePlaceholder"),
+      id: "last-name",
+      validation: fieldValidators.lastName,
     },
     {
       name: "username",

--- a/app/new-user/student/action.ts
+++ b/app/new-user/student/action.ts
@@ -11,8 +11,19 @@ export const signUpNewStudentAction = async (
   const locale = ((await cookies()).get("locale")?.value as Locale) || "en";
   const fieldValidators = getFieldValidators(getTranslator(locale));
 
+  const firstName = formData.get("firstName")?.toString() || "";
+  const lastName = formData.get("lastName")?.toString() || "";
+
+  const { isValid: isNameValid, errors: nameErrors } = await validateFormData(
+    { firstName, lastName },
+    { firstName: fieldValidators.firstName, lastName: fieldValidators.lastName }
+  );
+
   const data: SignUpUserData = {
-    fullname: formData.get("fullname")?.toString() || "",
+    fullname: `${firstName.replace(/\s+/g, "")} ${lastName.replace(
+      /\s+/g,
+      ""
+    )}`,
     username: formData.get("username")?.toString() || "",
     email: formData.get("email")?.toString() || "",
     dateOfBirth: formData.get("dateOfBirth")?.toString() || "",
@@ -22,7 +33,6 @@ export const signUpNewStudentAction = async (
   };
 
   const { isValid, errors } = await validateFormData(data, {
-    fullname: fieldValidators.fullname,
     username: fieldValidators.username,
     email: fieldValidators.email,
     dateOfBirth: fieldValidators.dateOfBirth,
@@ -30,10 +40,10 @@ export const signUpNewStudentAction = async (
     profileImage: fieldValidators.profileImage,
   });
 
-  if (!isValid) {
+  if (!isNameValid || !isValid) {
     return {
       success: false,
-      errors,
+      errors: { ...nameErrors, ...errors },
     };
   }
 

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -90,12 +90,9 @@ export const getValidations = (t: (key: string) => string) => ({
 
   fullname: (value: FormValue): ValidationResult => {
     if (typeof value !== "string") return null;
-    const fullnameRegex = /^[a-zA-Z ]+$/;
+    const fullnameRegex = /^[a-zA-Z؀-ۿ ]+$/;
     if (!fullnameRegex.test(value)) {
       return t("validationMessages.fullnameLetters");
-    }
-    if (!value.includes(" ") || value.split(" ").length < 2) {
-      return t("validationMessages.fullnameWords");
     }
     return null;
   },
@@ -239,7 +236,7 @@ export const getValidations = (t: (key: string) => string) => ({
   scoreName: async (value: FormValue): Promise<ValidationResult> => {
     if (typeof value !== "string") return null;
 
-    if (!/^[a-zA-Z ]+$/.test(value)) {
+    if (!/^[a-zA-Z؀-ۿ ]+$/.test(value)) {
       return t("validationMessages.scoreNameLetters");
     }
 
@@ -273,9 +270,15 @@ export const getFieldValidators = (t: (key: string) => string) => {
   const validations = getValidations(t);
 
   return {
-    fullname: createValidator(
-      validations.required(t("formFields.fullname")),
-      validations.minLength(2, t("formFields.fullname")),
+    firstName: createValidator(
+      validations.required(t("formFields.firstName")),
+      validations.minLength(2, t("formFields.firstName")),
+      validations.fullname
+    ),
+
+    lastName: createValidator(
+      validations.required(t("formFields.lastName")),
+      validations.minLength(2, t("formFields.lastName")),
       validations.fullname
     ),
 

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -141,7 +141,6 @@ const ar: Dictionary = {
   },
   addScorePopup: {
     title: "إضافة طالب",
-    fullNamePlaceholder: "الاسم الكامل",
     cancel: "إلغاء",
     add: "إضافة",
     successToast: "تمت إضافة الطالب بنجاح!",
@@ -160,8 +159,10 @@ const ar: Dictionary = {
     goHome: "العودة إلى الرئيسية",
   },
   formFields: {
-    fullname: "الاسم الكامل",
-    fullnamePlaceholder: "مثال: محمد صادق",
+    firstName: "الاسم الأول",
+    firstNamePlaceholder: "مثال: محمد",
+    lastName: "اسم العائلة",
+    lastNamePlaceholder: "مثال: صادق",
     username: "اسم المستخدم",
     usernamePlaceholder: "مثال: sadik123",
     dateOfBirth: "تاريخ الميلاد",
@@ -178,7 +179,6 @@ const ar: Dictionary = {
     required: "{field} مطلوب",
     minLength: "{field} يجب أن يحتوي على {min} أحرف على الأقل",
     fullnameLetters: "الاسم الكامل يجب أن يحتوي على أحرف ومسافات فقط",
-    fullnameWords: "الاسم الكامل يجب أن يحتوي على كلمتين على الأقل",
     emailInvalid: "يرجى إدخال بريد إلكتروني صحيح",
     usernameChars: "اسم المستخدم يمكن أن يحتوي فقط على أحرف وأرقام وشرطة سفلية",
     usernameTaken: "اسم المستخدم مستخدم بالفعل",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -141,7 +141,6 @@ const en = {
   },
   addScorePopup: {
     title: "Add Student",
-    fullNamePlaceholder: "Full Name",
     cancel: "Cancel",
     add: "Add",
     successToast: "Student added successfully!",
@@ -160,8 +159,10 @@ const en = {
     goHome: "Go to Home",
   },
   formFields: {
-    fullname: "Full Name",
-    fullnamePlaceholder: "e.g Mohammad Sadik",
+    firstName: "First Name",
+    firstNamePlaceholder: "e.g Mohammad",
+    lastName: "Last Name",
+    lastNamePlaceholder: "e.g Sadik",
     username: "Username",
     usernamePlaceholder: "e.g sadik123",
     dateOfBirth: "Date of birth",
@@ -178,7 +179,6 @@ const en = {
     required: "{field} is required",
     minLength: "{field} must be at least {min} characters",
     fullnameLetters: "Full name can only contain letters and spaces",
-    fullnameWords: "Full name must be at least 2 words",
     emailInvalid: "Please enter a valid email address",
     usernameChars: "Username can only contain letters, numbers, and underscores",
     usernameTaken: "Username is already taken",


### PR DESCRIPTION
Adds separate first/last name inputs for the scores list and signup forms, stripping internal whitespace from each part before combining into a single space-joined name for storage and uniqueness checks. Extends the underlying name regex to accept Arabic characters.